### PR TITLE
Fix broken test

### DIFF
--- a/test/tests-6to5-playground.js
+++ b/test/tests-6to5-playground.js
@@ -54,7 +54,7 @@ test("@foo();", {
         },
         "property": {
           "type": "CallExpression",
-          "start": 1,
+          "start": 0,
           "end": 6,
           "callee": {
             "type": "Identifier",


### PR DESCRIPTION
Starting from https://github.com/6to5/acorn-6to5/commit/40350cafb8d2c66cad7864e04792e9046734c633 this shorthand (`@`) also part of call expression.