### PR TITLE
Basic implementation of onDelimeter (work in progress)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -26,6 +26,9 @@
         if (expected.onToken = testOpts.onToken) {
           testOpts.onToken = [];
         }
+        if (expected.onDelimeter = testOpts.onDelimeter) {
+          testOpts.onDelimeter = [];
+        }
         var ast = parse(test.code, testOpts);
         if (test.error) {
           if (config.loose) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -28845,3 +28845,14 @@ test("#!/usr/bin/node\n;", {}, {
     end: 15
   }]
 });
+
+test('var x = 1 + 2;', {}, {
+  onDelimeter: [
+    { type: 32, line: 1, column: 3 },
+    { type: 32, line: 1, column: 5 },
+    { type: 32, line: 1, column: 7 },
+    { type: 32, line: 1, column: 9 },
+    { type: 32, line: 1, column: 11 }
+  ]
+});
+


### PR DESCRIPTION
Hey @6to5 folks!

Recently I've played with 6to5+acorn and found them super simple to use so I decided to build simple JS linter upon acorn-6to5.

Why not original repo? Basically I'm working on React-powered project and for me is crucial to have JSX support along with power of 6to5. So there is no way to use JSHint (or JSLint) because they are (a) out of sync with my transpiler features & settings and (b) they really hard to extend.

But eventually I've figured out that delimiters (spaces, tabs etc; I need them to check code style; as an illustation: https://github.com/airbnb/javascript#whitespace) are missing in AST and only one way to prevent double processing is to collect them inside of acorn (how it works for comments right now).

I'm opening this PR as discussion, to figure out how it fits into your plans. What do you think, any way to get this PR eventually merged or it's dead born-idea? Maybe you see potential problems since your more experienced with acorn.

_At the moment it works only for spaces (char code 32). Documentation for onDelimeter is pending._

Thanks!