### PR TITLE
Turn on playground for `"obj ?= 2"`

### DIFF
--- a/test/tests-6to5-playground.js
+++ b/test/tests-6to5-playground.js
@@ -197,7 +197,9 @@ test("var foo = { memo bar() {} };",
 
 // Memoization assignment operator
 
-testFail("obj ?= 2;", "You can only use member expressions in memoization assignment (1:0)");
+testFail("obj ?= 2;", "You can only use member expressions in memoization assignment (1:0)", {
+  playground: true
+});
 
 test("obj.x ?= 2;", {
   type: "Program",


### PR DESCRIPTION
Without it fail with different issue, doesn’t connected to real case: `Got error message: Unexpected token (1:5)`.