### PR TITLE
Fix ** operator associativity

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2515,9 +2515,17 @@
         var op = tokType;
         next();
         var start = storeCurrentPos();
-        node.right = parseExprOp(parseMaybeUnary(), start, prec, noIn);
+        if(op.rightAssociative) {
+          node.right = parseExprOp(parseMaybeUnary(), start, prec - 1, noIn);
+        } else {
+          node.right = parseExprOp(parseMaybeUnary(), start, prec, noIn);
+        }
         finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
-        return parseExprOp(node, leftStart, minPrec, noIn);
+        if(op.rightAssociative) {
+          return node;
+        } else {
+          return parseExprOp(node, leftStart, minPrec, noIn);
+        }
       }
     }
     return left;

--- a/acorn.js
+++ b/acorn.js
@@ -469,7 +469,7 @@
 
   // '*' may be multiply or have special meaning in ES6
   var _star = {binop: 10, beforeExpr: true};
-  var _exponent = {binop: 11, beforeExpr: true};
+  var _exponent = {binop: 11, beforeExpr: true, rightAssociative: true};
 
   // '<', '>' may be relational or have special meaning in JSX
   var _lt = {binop: 7, beforeExpr: true}, _gt = {binop: 7, beforeExpr: true};


### PR DESCRIPTION
The `**` operator was previously being parsed as left associative.

This pull request adds a new `rightAssociative` flag to the binop objects, and uses right recursion (rather than left recursion) in `parseExprOp` to parse these operators.