### PR TITLE
Fix right associative parse precedence

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2516,7 +2516,7 @@
         next();
         var start = storeCurrentPos();
         if(op.rightAssociative) {
-          node.right = parseExprOp(parseMaybeUnary(), start, prec - 1, noIn);
+          node.right = parseExprOp(parseMaybeUnary(), start, minPrec, noIn);
         } else {
           node.right = parseExprOp(parseMaybeUnary(), start, prec, noIn);
         }


### PR DESCRIPTION
This fixes the right associative parsing so that any operator with a higher precedence can be read on the right hand side, rather than another operator of the same precedence.