### PR TITLE
Keep acorn_csp.js for npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+!acorn_csp.js


### PR DESCRIPTION
The published version v0.11.1-17 doesn't include `acorn_csp.js`.
`.npmignore` is required to keep it on NPM module.