### PR TITLE
Update .npmignore to ignore big, not-used-in-NPM directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 !acorn_csp.js
+test
+docs


### PR DESCRIPTION
Ignore `test` (2.7MB) and `docs` (651KB)